### PR TITLE
Implement rocket booking

### DIFF
--- a/src/components/rockets/Rockets.jsx
+++ b/src/components/rockets/Rockets.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import { fetchRockets } from '../../redux/rockets/rocketsSlice';
+import { fetchRockets, reserveRocket } from '../../redux/rockets/rocketsSlice';
 
 const Rockets = () => {
   const dispatch = useDispatch();
@@ -23,7 +23,13 @@ const Rockets = () => {
               <div className="card-body">
                 <h5 className="card-title">{rocket.rocketName}</h5>
                 <p className="card-text">{rocket.rocketDescription}</p>
-                <button type="button" className="btn btn-primary">Reserve Rocket</button>
+                <button
+                  type="button"
+                  className="btn btn-primary"
+                  onClick={() => dispatch(reserveRocket(rocket.rocketId))}
+                >
+                  Reserve Rocket
+                </button>
               </div>
             </div>
           </div>

--- a/src/redux/rockets/rocketsSlice.js
+++ b/src/redux/rockets/rocketsSlice.js
@@ -23,7 +23,14 @@ const rocketsSlice = createSlice({
   name: 'rockets',
   initialState,
   reducers: {
-
+    reserveRocket: (state, action) => {
+      const id = action.payload;
+      const rockets = state.rockets.map((rocket) => {
+        if (rocket.rocketId !== id) return rocket;
+        return { ...rocket, reserved: true };
+      });
+      return { ...state, rockets };
+    },
   },
   extraReducers: (builder) => {
     builder.addCase(fetchRockets.pending, (state) => ({
@@ -45,6 +52,7 @@ const rocketsSlice = createSlice({
 });
 
 export default rocketsSlice.reducer;
+export const { reserveRocket } = rocketsSlice.actions;
 export {
   fetchRockets,
 };


### PR DESCRIPTION
This PR fixes #12. 

I did the following:
- I added a reducer to the rocket's slice to reserve a rocket when the `Reserve` button is clicked.
- I dispatched the `reserveRocket` action when the `Reserve rocket` button on the rockets page was clicked.